### PR TITLE
Add smart step editor and failure logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository contains a simple Python GUI application for creating and execut
 - Write to and read from PLC data blocks
 - Expect specific values and verify them step-by-step
 - Save and load test plans as JSON files
+- Integrated step editor with validation and smart suggestions for next actions
+- Detailed failure log identifying which step failed and why
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- provide a unified step editor dialog with validation and simple suggestions for likely next steps
- log test step failures with step numbers and reasons
- document new editor and logging features in README

## Testing
- `python -m py_compile plc_tester_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad654341a8832fb80430806476e6b5