### PR TITLE
Add step editing GUI with navigation button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a simple Python GUI application for creating and execut
 - Expect specific values and verify them step-by-step
 - Save and load test plans as JSON files
 - Integrated step editor with validation and smart suggestions for next actions
+- Edit existing steps through a dedicated editor
 - Detailed failure log identifying which step failed and why
 
 ## Usage


### PR DESCRIPTION
## Summary
- Allow editing existing steps in the test plan via StepEditor with pre-filled values
- Add an Edit button to the steps list for easy navigation to the editor
- Document step editing in the README

## Testing
- `python -m py_compile plc_tester_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad679ab6fc832fb15cd202c418e0f1