### PR TITLE
feat: add typed multi-address support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This repository contains a simple Python GUI application for creating and execut
 - Define modules, tests, and individual steps in a friendly GUI
 - Write to and read from PLC data blocks
 - Expect specific values and verify them step-by-step
+- Execute simple delays between actions to build timer-based sequences
+- Write and read multiple address/value pairs within a single step
+- Support common Siemens data types (BOOL, BYTE, WORD, DWORD, INT, DINT, REAL)
 - Save and load test plans as JSON files
 - Integrated step editor with validation and smart suggestions for next actions
 - Edit existing steps through a dedicated editor
@@ -23,4 +26,11 @@ This repository contains a simple Python GUI application for creating and execut
    python plc_tester_gui.py
    ```
 3. Use the interface to create modules, add tests and steps, and run them against the connected PLC. Results appear in the log area.
+
+### Step Input Tips
+
+- Multiple start bytes can be entered separated by commas (e.g. `0,4,8`).
+- Provide matching data types separated by commas (e.g. `INT,REAL`). Use `byte.bit` for BOOL addresses.
+- Enter corresponding write or expected values separated by commas (e.g. `5,3.14`).
+- An optional delay (milliseconds) can be specified to pause before executing the step's operations.
 

--- a/plc_tester_gui.py
+++ b/plc_tester_gui.py
@@ -3,13 +3,28 @@ A simple GUI to create and run PLC test plans using Snap7.
 """
 
 import json
+import time
 from dataclasses import dataclass, field, asdict
-from typing import List
+from typing import Any, List
 
 import tkinter as tk
-from tkinter import ttk, messagebox, simpledialog, filedialog
+from tkinter import filedialog, messagebox, simpledialog, ttk
 
 import snap7
+from snap7.util import (
+    get_bool,
+    get_dint,
+    get_dword,
+    get_int,
+    get_real,
+    get_word,
+    set_bool,
+    set_dint,
+    set_dword,
+    set_int,
+    set_real,
+    set_word,
+)
 
 
 @dataclass
@@ -17,9 +32,11 @@ class TestStep:
     """Single action within a test case."""
     description: str
     db_number: int
-    start: int
-    write: List[int] | None = None
-    expected: List[int] | None = None
+    start: int | str | List[int | str]
+    data_type: str | List[str]
+    write: Any | List[Any] | None = None
+    expected: Any | List[Any] | None = None
+    delay_ms: int | None = None
 
 
 @dataclass
@@ -56,6 +73,15 @@ class TestPlan:
         return cls(modules=modules)
 
 
+TYPE_FUNCS = {
+    "INT": (2, set_int, get_int),
+    "DINT": (4, set_dint, get_dint),
+    "WORD": (2, set_word, get_word),
+    "DWORD": (4, set_dword, get_dword),
+    "REAL": (4, set_real, get_real),
+}
+
+
 class StepEditor(tk.Toplevel):
     """Dialog to create or edit a :class:`TestStep`.
 
@@ -75,17 +101,34 @@ class StepEditor(tk.Toplevel):
         self.description_var = tk.StringVar()
         self.db_var = tk.StringVar()
         self.start_var = tk.StringVar()
+        self.type_var = tk.StringVar()
         self.write_var = tk.StringVar()
         self.expected_var = tk.StringVar()
+        self.delay_var = tk.StringVar()
 
         if step:
             self.description_var.set(step.description)
             self.db_var.set(str(step.db_number))
-            self.start_var.set(str(step.start))
-            if step.write:
-                self.write_var.set(",".join(str(b) for b in step.write))
-            if step.expected:
-                self.expected_var.set(",".join(str(b) for b in step.expected))
+            if isinstance(step.start, list):
+                self.start_var.set(",".join(str(s) for s in step.start))
+            else:
+                self.start_var.set(str(step.start))
+            if isinstance(step.data_type, list):
+                self.type_var.set(",".join(step.data_type))
+            else:
+                self.type_var.set(step.data_type)
+            if step.write is not None:
+                if isinstance(step.write, list):
+                    self.write_var.set(",".join(str(v) for v in step.write))
+                else:
+                    self.write_var.set(str(step.write))
+            if step.expected is not None:
+                if isinstance(step.expected, list):
+                    self.expected_var.set(",".join(str(v) for v in step.expected))
+                else:
+                    self.expected_var.set(str(step.expected))
+            if step.delay_ms is not None:
+                self.delay_var.set(str(step.delay_ms))
 
         frm = ttk.Frame(self)
         frm.pack(padx=10, pady=10)
@@ -96,17 +139,31 @@ class StepEditor(tk.Toplevel):
         ttk.Label(frm, text="DB number").grid(row=1, column=0, sticky="w")
         ttk.Entry(frm, textvariable=self.db_var, width=10).grid(row=1, column=1, sticky="w")
 
-        ttk.Label(frm, text="Start byte").grid(row=2, column=0, sticky="w")
-        ttk.Entry(frm, textvariable=self.start_var, width=10).grid(row=2, column=1, sticky="w")
+        ttk.Label(frm, text="Start address(es)").grid(row=2, column=0, sticky="w")
+        ttk.Entry(frm, textvariable=self.start_var, width=20).grid(row=2, column=1, sticky="w")
 
-        ttk.Label(frm, text="Write bytes (comma)").grid(row=3, column=0, sticky="w")
-        ttk.Entry(frm, textvariable=self.write_var, width=20).grid(row=3, column=1, sticky="w")
+        ttk.Label(frm, text="Data type(s)").grid(row=3, column=0, sticky="w")
+        ttk.Entry(frm, textvariable=self.type_var, width=20).grid(row=3, column=1, sticky="w")
 
-        ttk.Label(frm, text="Expected bytes").grid(row=4, column=0, sticky="w")
-        ttk.Entry(frm, textvariable=self.expected_var, width=20).grid(row=4, column=1, sticky="w")
+        ttk.Label(frm, text="Write values (comma)").grid(row=4, column=0, sticky="w")
+        ttk.Entry(frm, textvariable=self.write_var, width=30).grid(
+            row=4, column=1, sticky="w"
+        )
+
+        ttk.Label(frm, text="Expected values (comma)").grid(
+            row=5, column=0, sticky="w"
+        )
+        ttk.Entry(frm, textvariable=self.expected_var, width=30).grid(
+            row=5, column=1, sticky="w"
+        )
+
+        ttk.Label(frm, text="Delay ms").grid(row=6, column=0, sticky="w")
+        ttk.Entry(frm, textvariable=self.delay_var, width=10).grid(
+            row=6, column=1, sticky="w"
+        )
 
         btn_frm = ttk.Frame(frm)
-        btn_frm.grid(row=5, column=0, columnspan=2, pady=(10, 0))
+        btn_frm.grid(row=7, column=0, columnspan=2, pady=(10, 0))
         ttk.Button(btn_frm, text="OK", command=self._on_ok).grid(row=0, column=0, padx=5)
         ttk.Button(btn_frm, text="Cancel", command=self.destroy).grid(row=0, column=1, padx=5)
 
@@ -121,18 +178,66 @@ class StepEditor(tk.Toplevel):
             if not desc:
                 raise ValueError("Description required")
             db = int(self.db_var.get())
-            start = int(self.start_var.get())
+            start_tokens = [s.strip() for s in self.start_var.get().split(",") if s.strip()]
+            if not start_tokens:
+                raise ValueError("Start address required")
+            starts: List[int | str] = []
+            for tok in start_tokens:
+                if "." in tok:
+                    byte, bit = tok.split(".")
+                    starts.append(f"{int(byte)}.{int(bit)}")
+                else:
+                    starts.append(int(tok))
 
-            write = [int(x) for x in self.write_var.get().split(",") if x.strip()]
-            write = write or None
-            expected = [int(x) for x in self.expected_var.get().split(",") if x.strip()]
-            expected = expected or None
+            type_tokens = [t.strip().upper() for t in self.type_var.get().split(",") if t.strip()]
+            if not type_tokens:
+                raise ValueError("Data type required")
+            if len(type_tokens) == 1 and len(starts) > 1:
+                type_tokens = type_tokens * len(starts)
+            if len(type_tokens) != len(starts):
+                raise ValueError("Data types must match start addresses")
+
+            write_tokens = [w.strip() for w in self.write_var.get().split(",") if w.strip()]
+            expected_tokens = [e.strip() for e in self.expected_var.get().split(",") if e.strip()]
+            write_vals: List[Any] = []
+            expected_vals: List[Any] = []
+            if write_tokens:
+                if len(write_tokens) != len(starts):
+                    raise ValueError("Write values must match start addresses")
+                write_vals = [self._parse_value(tok, type_tokens[i]) for i, tok in enumerate(write_tokens)]
+            if expected_tokens:
+                if len(expected_tokens) != len(starts):
+                    raise ValueError("Expected values must match start addresses")
+                expected_vals = [self._parse_value(tok, type_tokens[i]) for i, tok in enumerate(expected_tokens)]
+
+            delay_ms = int(self.delay_var.get()) if self.delay_var.get().strip() else None
         except ValueError as exc:
             messagebox.showerror("Invalid input", str(exc))
             return
 
-        self.result = TestStep(desc, db, start, write, expected)
+        start_val: int | str | List[int | str] = starts[0] if len(starts) == 1 else starts
+        type_val: str | List[str] = type_tokens[0] if len(type_tokens) == 1 else type_tokens
+        write_val: Any | List[Any] | None = None
+        if write_vals:
+            write_val = write_vals[0] if len(write_vals) == 1 else write_vals
+        expected_val: Any | List[Any] | None = None
+        if expected_vals:
+            expected_val = expected_vals[0] if len(expected_vals) == 1 else expected_vals
+
+        self.result = TestStep(
+            desc, db, start_val, type_val, write_val, expected_val, delay_ms
+        )
         self.destroy()
+
+    def _parse_value(self, token: str, dtype: str) -> Any:
+        try:
+            if dtype == "REAL":
+                return float(token)
+            if dtype == "BOOL":
+                return token.lower() in {"1", "true", "t", "yes"}
+            return int(token)
+        except ValueError as exc:  # pragma: no cover - simple validation
+            raise ValueError(f"Invalid {dtype} value: {token}") from exc
 
 
 class PLCConnection:
@@ -289,9 +394,31 @@ class PLCTestGUI:
         test = self.current_test()
         if test:
             for s in test.steps:
-                write = ",".join(str(b) for b in s.write or [])
-                exp = ",".join(str(b) for b in s.expected or [])
-                self.step_list.insert(tk.END, f"{s.description} | DB{s.db_number} [{s.start}] W:{write} E:{exp}")
+                start = (
+                    ",".join(str(st) for st in s.start)
+                    if isinstance(s.start, list)
+                    else str(s.start)
+                )
+                dtype = (
+                    ",".join(s.data_type)
+                    if isinstance(s.data_type, list)
+                    else s.data_type
+                )
+
+                def fmt(val: Any | List[Any] | None) -> str:
+                    if val is None:
+                        return ""
+                    if isinstance(val, list):
+                        return ",".join(str(v) for v in val)
+                    return str(val)
+
+                write = fmt(s.write)
+                exp = fmt(s.expected)
+                delay = f" D:{s.delay_ms}ms" if s.delay_ms else ""
+                self.step_list.insert(
+                    tk.END,
+                    f"{s.description} | DB{s.db_number} [{start}] T:{dtype} W:{write} E:{exp}{delay}",
+                )
 
     def log_msg(self, msg: str) -> None:
         self.log.insert(tk.END, msg + "\n")
@@ -371,9 +498,10 @@ class PLCTestGUI:
     def suggest_next_step(self, step: TestStep) -> None:
         """Provide simple suggestions for likely next steps."""
 
+        first_start = step.start[0] if isinstance(step.start, list) else step.start
         if step.write and not step.expected:
             self.log_msg(
-                f"Suggestion: add a verification step for DB{step.db_number} start {step.start}."
+                f"Suggestion: add a verification step for DB{step.db_number} start {first_start}."
             )
         elif step.expected and not step.write:
             self.log_msg("Suggestion: add a write step before verifying these bytes.")
@@ -433,19 +561,88 @@ class PLCTestGUI:
         for idx, step in enumerate(test.steps, start=1):
             self.log_msg(f"    Step {idx}: {step.description}")
             try:
-                if step.write:
-                    self.conn.write(step.db_number, step.start, bytes(step.write))
-                if step.expected:
-                    data = self.conn.read(step.db_number, step.start, len(step.expected))
-                    ok = list(data) == step.expected
-                    self.log_msg(
-                        f"      Expect {step.expected} got {list(data)} -> {'OK' if ok else 'FAIL'}"
-                    )
-                    if not ok:
-                        failures.append(
-                            f"step {idx} ({step.description}): expected {step.expected} got {list(data)}"
-                        )
-                        success = False
+                starts = step.start if isinstance(step.start, list) else [step.start]
+                types = (
+                    step.data_type
+                    if isinstance(step.data_type, list)
+                    else [step.data_type]
+                )
+                if len(types) == 1 and len(starts) > 1:
+                    types = types * len(starts)
+                writes = (
+                    step.write if isinstance(step.write, list) else ([step.write] if step.write is not None else [])
+                )
+                expecteds = (
+                    step.expected
+                    if isinstance(step.expected, list)
+                    else ([step.expected] if step.expected is not None else [])
+                )
+
+                if step.delay_ms:
+                    self.log_msg(f"      Waiting {step.delay_ms} ms")
+                    time.sleep(step.delay_ms / 1000.0)
+
+                for sub_idx, start in enumerate(starts):
+                    dtype = types[sub_idx]
+                    w = writes[sub_idx] if sub_idx < len(writes) else None
+                    e = expecteds[sub_idx] if sub_idx < len(expecteds) else None
+                    if dtype == "BOOL":
+                        byte_str, bit_str = str(start).split(".")
+                        byte_idx, bit_idx = int(byte_str), int(bit_str)
+                        if w is not None:
+                            cur = bytearray(self.conn.read(step.db_number, byte_idx, 1))
+                            set_bool(cur, 0, bit_idx, bool(w))
+                            self.conn.write(step.db_number, byte_idx, bytes(cur))
+                        if e is not None:
+                            data = self.conn.read(step.db_number, byte_idx, 1)
+                            val = get_bool(data, 0, bit_idx)
+                            ok = val == bool(e)
+                            self.log_msg(
+                                f"      Expect {e} got {val} -> {'OK' if ok else 'FAIL'}"
+                            )
+                            if not ok:
+                                failures.append(
+                                    f"step {idx} ({step.description}) at {start}: expected {e} got {val}"
+                                )
+                                success = False
+                    elif dtype == "BYTE":
+                        addr = int(start)
+                        if w is not None:
+                            self.conn.write(step.db_number, addr, bytes([int(w)]))
+                        if e is not None:
+                            data = self.conn.read(step.db_number, addr, 1)
+                            val = data[0]
+                            ok = val == int(e)
+                            self.log_msg(
+                                f"      Expect {e} got {val} -> {'OK' if ok else 'FAIL'}"
+                            )
+                            if not ok:
+                                failures.append(
+                                    f"step {idx} ({step.description}) at {start}: expected {e} got {val}"
+                                )
+                                success = False
+                    else:
+                        size, set_func, get_func = TYPE_FUNCS[dtype]
+                        addr = int(start)
+                        if w is not None:
+                            buf = bytearray(size)
+                            set_func(buf, 0, w)
+                            self.conn.write(step.db_number, addr, bytes(buf))
+                        if e is not None:
+                            data = self.conn.read(step.db_number, addr, size)
+                            val = get_func(data, 0)
+                            if dtype == "REAL":
+                                ok = abs(val - float(e)) < 1e-6
+                            else:
+                                ok = val == e
+                            self.log_msg(
+                                f"      Expect {e} got {val} -> {'OK' if ok else 'FAIL'}"
+                            )
+                            if not ok:
+                                failures.append(
+                                    f"step {idx} ({step.description}) at {start}: expected {e} got {val}"
+                                )
+                                success = False
             except Exception as exc:  # pragma: no cover - network
                 self.log_msg(f"      Error: {exc}")
                 failures.append(f"step {idx} ({step.description}): {exc}")


### PR DESCRIPTION
## Summary
- allow specifying Siemens data types per start address
- extend step editor to capture types and values
- implement typed read/write logic for BOOL, BYTE, WORD, DWORD, INT, DINT and REAL

## Testing
- `python -m py_compile plc_tester_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad6dcbb034832fabda85a747d44634