### PR TITLE
Enhance JSON editor with auto-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains a simple Python GUI application for creating and execut
 - Integrated step editor with validation and smart suggestions for next actions
 - Edit existing steps through a dedicated editor
 - Detailed failure log identifying which step failed and why
-- Built-in JSON editor with live syntax checking and templates
+- Built-in JSON editor with live syntax checking, auto-completion, and templates
 
 ## Usage
 
@@ -32,7 +32,8 @@ This repository contains a simple Python GUI application for creating and execut
 
 Test plans can be represented as JSON and executed directly from the GUI. Use
 the **JSON Editor** button in the *Run* frame to open a helper that validates
-syntax as you type and offers quick templates for modules, tests, and steps.
+syntax as you type, suggests field names, supports Tab-based auto-completion,
+and offers quick templates for modules, tests, and steps.
 Modify the JSON as needed and press **Run** to execute it against the currently
 connected PLC. Plans can also be saved to or loaded from disk using the standard
 file dialogs.


### PR DESCRIPTION
## Summary
- add keyword suggestions and Tab-completion to the built-in JSON editor
- automatically insert matching braces/quotes to help prevent syntax errors
- document JSON editor improvements in README

## Testing
- `python -m py_compile plc_tester_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad7f206cd0832fb4c5ea79242b56aa