### PR TITLE
Add support for M memory area

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a simple Python GUI application for creating and execut
 ## Features
 
 - Define modules, tests, and individual steps in a friendly GUI
-- Write to and read from PLC data blocks
+- Write to and read from PLC data blocks and M memory
 - Expect specific values and verify them step-by-step
 - Execute simple delays between actions to build timer-based sequences
 - Write and read multiple address/value pairs within a single step
@@ -48,4 +48,5 @@ file dialogs.
 - Provide matching data types separated by commas (e.g. `INT,REAL`). Use `byte.bit` for BOOL addresses.
 - Enter corresponding write or expected values separated by commas (e.g. `5,3.14`).
 - An optional delay (milliseconds) can be specified to pause before executing the step's operations.
+- Choose the memory area (DB or M); DB number is ignored when using M.
 


### PR DESCRIPTION
## Summary
- allow test steps and GUI to select DB or M memory area
- handle M area reads and writes within PLCConnection
- document M memory usage in README

## Testing
- `python -m py_compile plc_tester_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad97333ca0832f9b77d61e246152b8