### PR TITLE
Handle non-missing snap7 import failures

### DIFF
--- a/plc_tester_gui.py
+++ b/plc_tester_gui.py
@@ -28,7 +28,10 @@ try:
         set_word,
     )
     from snap7.snap7types import areas
-except Exception:  # pragma: no cover - optional dependency
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    # Only treat a missing module as optional. Other import errors should
+    # surface so users see the underlying issue instead of being told the
+    # dependency is simply absent.
     snap7 = None
 
     def _missing_snap7(*_args: object, **_kwargs: object) -> None:

--- a/tests/test_snap7_import_error.py
+++ b/tests/test_snap7_import_error.py
@@ -1,0 +1,23 @@
+import importlib
+import builtins
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_snap7_import_error_propagates(monkeypatch):
+    """Import errors other than missing module should not be masked."""
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "snap7":
+            raise OSError("broken snap7")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("plc_tester_gui", None)
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+    with pytest.raises(OSError, match="broken snap7"):
+        importlib.import_module("plc_tester_gui")


### PR DESCRIPTION
## Summary
- Avoid masking snap7 import errors by only catching ModuleNotFoundError
- Add regression test ensuring other snap7 import failures surface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9e9848c0832fb58a14e627d5e0bb