### PR TITLE
Handle snap7 Areas enum

### DIFF
--- a/plc_tester_gui.py
+++ b/plc_tester_gui.py
@@ -34,7 +34,7 @@ try:
     try:  # snap7 >= 2
         from snap7.type import Areas
 
-        areas = {name: int(member) for name, member in Areas.__members__.items()}
+        areas = {name: member for name, member in Areas.__members__.items()}
     except Exception:  # pragma: no cover - fall back for older versions
         from snap7.snap7types import areas  # type: ignore[import]
 except ModuleNotFoundError:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- Use snap7 enum objects directly for area mapping to avoid attribute errors when libraries expect `.name`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adac2c6de4832fa5574ac95c36e749