### PR TITLE
fix: hashable test plan dataclasses

### DIFF
--- a/plc_tester_gui.py
+++ b/plc_tester_gui.py
@@ -89,7 +89,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
     areas: Dict[str, int] = {}
 
 
-@dataclass
+@dataclass(eq=False)
 class TestStep:
     """Single action within a test case."""
     description: str
@@ -102,14 +102,14 @@ class TestStep:
     area: str = "DB"
 
 
-@dataclass
+@dataclass(eq=False)
 class TestCase:
     """Collection of steps to validate a module behaviour."""
     name: str
     steps: List[TestStep] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(eq=False)
 class ModulePlan:
     """Group of test cases for a specific module."""
     name: str


### PR DESCRIPTION
## Summary
- Ensure TestStep, TestCase, and ModulePlan dataclasses are hashable by identity
- Prevent `TypeError: unhashable type` when tracking results in dictionaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc3c4e75c832f9e24ae288b53eab9