### PR TITLE
Add copy/edit controls and drag-and-drop reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains a simple Python GUI application for creating and execut
 - Detailed failure log identifying which step failed and why
 - Built-in JSON editor with live syntax checking, auto-completion, and templates
 - Edit JSON for individual modules, tests, or steps with automatic plan updates
+- Duplicate modules, tests, and steps and reorder them via drag-and-drop
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- allow duplicating and renaming modules, tests, and steps
- reorder modules, tests, and steps via drag and drop
- document copy and reordering capabilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1513cf028832fb4a028c1a7c78feb