### PR TITLE
Default step delay to 10ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ file dialogs.
 - Multiple start bytes can be entered separated by commas (e.g. `0,4,8`).
 - Provide matching data types separated by commas (e.g. `INT,REAL`). Use `byte.bit` for BOOL addresses.
 - Enter corresponding write or expected values separated by commas (e.g. `5,3.14`).
-- An optional delay (milliseconds) can be specified to pause before executing the step's operations.
+- An optional delay (milliseconds) can be specified to pause before executing the step's operations (defaults to 10 ms).
 - Choose the memory area (DB or M); DB number is ignored when using M.
 

--- a/plc_tester_gui.py
+++ b/plc_tester_gui.py
@@ -263,7 +263,7 @@ class StepEditor(tk.Toplevel):
         self.type_var = tk.StringVar()
         self.write_var = tk.StringVar()
         self.expected_var = tk.StringVar()
-        self.delay_var = tk.StringVar()
+        self.delay_var = tk.StringVar(value="10")
         self.area_var = tk.StringVar(value="DB")
 
         if step:
@@ -506,7 +506,7 @@ class PlanJsonEditor(tk.Toplevel):
         '  "data_type": "INT",\n'
         '  "write": 0,\n'
         '  "expected": 0,\n'
-        '  "delay_ms": 0\n}'
+        '  "delay_ms": 10\n}'
     )
 
     KEYWORDS = [


### PR DESCRIPTION
## Summary
- Pre-fill step editor delay field with a 10ms default
- Update JSON step template to use 10ms default delay
- Document default delay in step input tips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b15f8cfa70832f85a84c5091427ae3